### PR TITLE
Fix: Theming

### DIFF
--- a/README.md
+++ b/README.md
@@ -219,6 +219,89 @@ function CompletelyCustomChat() {
 }
 ```
 
+## Theming and Customization
+
+### Theme Mode Control
+
+The SDK automatically detects your system's theme preference (light/dark mode), but you can override this behavior using the `themeMode` prop. This is especially useful for integration with documentation sites like Docusaurus:
+
+```tsx
+import { PromptQLChat } from "promptql-chat-sdk";
+
+function App() {
+  return (
+    <div>
+      {/* Auto-detect system theme (default) */}
+      <PromptQLChat endpoint="/api" themeMode="auto" />
+
+      {/* Force light theme */}
+      <PromptQLChat endpoint="/api" themeMode="light" />
+
+      {/* Force dark theme */}
+      <PromptQLChat endpoint="/api" themeMode="dark" />
+    </div>
+  );
+}
+```
+
+#### Docusaurus Integration
+
+For Docusaurus sites, you can sync the chat theme with your site's theme:
+
+```tsx
+import { useColorMode } from '@docusaurus/theme-common';
+import { PromptQLChat } from "promptql-chat-sdk";
+
+function DocusaurusChat() {
+  const { colorMode } = useColorMode();
+
+  return (
+    <PromptQLChat
+      endpoint="/api"
+      themeMode={colorMode} // 'light' or 'dark'
+      title="Documentation Assistant"
+    />
+  );
+}
+```
+
+### Custom Colors
+
+You can customize the primary colors while maintaining theme consistency:
+
+```tsx
+<PromptQLChat
+  endpoint="/api"
+  themeMode="auto"
+  primaryColor="#10b981"
+  backgroundColor="#f8fafc"
+  textColor="#1e293b"
+/>
+```
+
+### Headless Hook Theming
+
+The headless hook also supports theme mode control:
+
+```tsx
+import { usePromptQLChat } from "promptql-chat-sdk";
+
+function CustomChat() {
+  const { theme, isDarkMode } = usePromptQLChat({
+    endpoint: "/api",
+    themeMode: "dark", // Force dark mode
+    primaryColor: "#3b82f6"
+  });
+
+  // Use theme.colors for styling your custom components
+  return (
+    <div style={{ backgroundColor: theme.colors.background }}>
+      {/* Your custom UI */}
+    </div>
+  );
+}
+```
+
 ## Authentication
 
 The SDK requires a proxy server to handle authentication. The proxy server should add the necessary headers for

--- a/src/lib/components/PromptQLChat/index.tsx
+++ b/src/lib/components/PromptQLChat/index.tsx
@@ -25,6 +25,7 @@ import "../../styles/components.css";
  */
 const PromptQLChat: React.FC<PromptQLChatProps> = ({
   endpoint,
+  themeMode = 'auto',
   primaryColor,
   backgroundColor,
   textColor,
@@ -171,7 +172,7 @@ const PromptQLChat: React.FC<PromptQLChatProps> = ({
   );
 
   // Hooks
-  const themeDetection = useThemeDetection();
+  const themeDetection = useThemeDetection(themeMode);
   const threadPersistence = useThreadPersistence("promptql-chat");
   const modalPersistence = useModalPersistence("promptql-chat");
   const api = usePromptQLAPI(endpoint);

--- a/src/lib/hooks/usePromptQLChat.ts
+++ b/src/lib/hooks/usePromptQLChat.ts
@@ -12,6 +12,7 @@ import type { Message, Theme, ConnectionState, PromptQLError } from "../types";
  */
 export interface UsePromptQLChatConfig {
   endpoint: string; // Should point to your secure proxy server
+  themeMode?: 'light' | 'dark' | 'auto';
   primaryColor?: string;
   backgroundColor?: string;
   textColor?: string;
@@ -88,7 +89,7 @@ export interface UsePromptQLChatReturn {
  * ```
  */
 export function usePromptQLChat(config: UsePromptQLChatConfig): UsePromptQLChatReturn {
-  const { endpoint, primaryColor, backgroundColor, textColor, onThreadStart, onError } = config;
+  const { endpoint, themeMode = 'auto', primaryColor, backgroundColor, textColor, onThreadStart, onError } = config;
 
   // Chat state
   const [messages, setMessages] = useState<Message[]>([]);
@@ -151,7 +152,7 @@ export function usePromptQLChat(config: UsePromptQLChatConfig): UsePromptQLChatR
   }, []);
 
   // Initialize hooks
-  const themeDetection = useThemeDetection();
+  const themeDetection = useThemeDetection(themeMode);
   const threadPersistence = useThreadPersistence("promptql-chat");
   const modalPersistence = useModalPersistence("promptql-chat");
   const api = usePromptQLAPI(endpoint);

--- a/src/lib/types/index.ts
+++ b/src/lib/types/index.ts
@@ -142,6 +142,8 @@ export interface PromptQLChatProps {
   /** PromptQL API endpoint URL (should point to your secure proxy server) */
   endpoint: string;
 
+  /** Theme mode override - 'light', 'dark', or 'auto' (default: 'auto' uses system preference) */
+  themeMode?: 'light' | 'dark' | 'auto';
   /** Primary color for theming */
   primaryColor?: string;
   /** Background color for theming */


### PR DESCRIPTION
## Description

This adds explicit theme mode control to the PromptQL Chat SDK.

 - Adds `themeMode` prop with `'light'`, `'dark'`, and `'auto'` options
 - Particularly useful for documentation sites that need to sync chat themes
 - Maintains backward compatibility (shocking, I know)
 Previously, the SDK was a bit presumptuous - it would just assume you wanted it to follow your system theme:

```tsx
 <PromptQLChat endpoint="/api" />
 // Always used system preference, no questions asked
```

 The theme detection hook was equally stubborn:

```tsx
 const themeDetection = useThemeDetection();
 // One size fits all approach
```
 Now you can actually tell it what to do:

```tsx
 // For when you want to be explicit about your life choices
 <PromptQLChat endpoint="/api" themeMode="dark" />

 // Or sync with a site's theme
 function DocusaurusChat() {
   const { colorMode } = useColorMode();

   return (
     <PromptQLChat
       endpoint="/api"
       themeMode={colorMode} // Actually respects the parent's decisions
       title="Documentation Assistant"
     />
   );
 }
```

 The headless hook gets the same treatment:

```tsx
 const { theme, isDarkMode } = usePromptQLChat({
   endpoint: "/api",
   themeMode: "dark", // No more guessing games
   primaryColor: "#3b82f6"
 });
```